### PR TITLE
Support added for the bq zum board. Board id: arduino:avr:bt

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -338,6 +338,11 @@ pressed: { border: 1px };</string>
           <string>arduino:avr:mega</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>arduino:avr:bt</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item>


### PR DESCRIPTION
I have changed the mainwindow.ui file to add the board id: "arduino:avr:bt" so that the bq zum board can now be used with visualino :-)

  I have checked it on my ubuntu 14.04 linux and it works fine. It should also be checked in other OS
