### PR TITLE
Polish translation

### DIFF
--- a/ts/visualino_pl-pl.ts
+++ b/ts/visualino_pl-pl.ts
@@ -6,12 +6,12 @@
     <message>
         <location filename="../src/aboutdialog.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished">O Visualino </translation>
+        <translation>O Visualino </translation>
     </message>
     <message>
         <location filename="../src/aboutdialog.ui" line="30"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Visualino is open source software (MIT license). Visit the web site at &lt;a href=&quot;http://www.visualino.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;visualino.net&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;2014-2015 Víctor R. Ruiz &amp;lt;&lt;a href=&quot;mailto:rvr@linotipo.es&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;rvr@linotipo.es&lt;/span&gt;&lt;/a&gt;&amp;gt;&lt;/p&gt;&lt;p&gt;It uses the following open source projects:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.qt.io/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Qt 5&lt;/span&gt;&lt;/a&gt;, The Qt Company (LGPL license 2.1).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://developers.google.com/blockly/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Google Blockly&lt;/span&gt;&lt;/a&gt; (MIT license).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/bq/roboblocks&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Roboblocks&lt;/span&gt;&lt;/a&gt;, bq (LGPL license).&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;This project is done with the help of &lt;a href=&quot;http://www.facebook.com/groups/arduinograncanaria&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Arduino Gran Canaria&lt;/span&gt;&lt;/a&gt; members.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Visualino jest oprogramowaniem Open Source (licencja MIT). Odwiedź witrynę &lt;a href=&quot;http://www.visualino.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;visualino.net&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;2014-2015 Víctor R. Ruiz &amp;lt;&lt;a href=&quot;mailto:rvr@linotipo.es&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;rvr@linotipo.es&lt;/span&gt;&lt;/a&gt;&amp;gt;&lt;/p&gt;&lt;p&gt;Używa następujących plików projektów Open Source:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.qt.io/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Qt 5&lt;/span&gt;&lt;/a&gt;, The Qt Company (LGPL license 2.1).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://developers.google.com/blockly/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Google Blockly&lt;/span&gt;&lt;/a&gt; (licencja MIT).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/bq/roboblocks&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Roboblocks&lt;/span&gt;&lt;/a&gt;, bq (licencja LGPL).&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Ten projekt wykonano z pomocą członków &lt;a href=&quot;http://www.facebook.com/groups/arduinograncanaria&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Arduino Gran Canaria&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Visualino jest oprogramowaniem Open Source (licencja MIT). Odwiedź witrynę &lt;a href=&quot;http://www.visualino.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;visualino.net&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;2014-2015 Víctor R. Ruiz &amp;lt;&lt;a href=&quot;mailto:rvr@linotipo.es&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;rvr@linotipo.es&lt;/span&gt;&lt;/a&gt;&amp;gt;&lt;/p&gt;&lt;p&gt;Użyto następujących plików projektów Open Source:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.qt.io/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Qt 5&lt;/span&gt;&lt;/a&gt;, The Qt Company (licencja LGPL 2.1).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://developers.google.com/blockly/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Google Blockly&lt;/span&gt;&lt;/a&gt; (licencja MIT).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/bq/roboblocks&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Roboblocks&lt;/span&gt;&lt;/a&gt;, bq (licencja LGPL).&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Ten projekt wykonano z pomocą członków &lt;a href=&quot;http://www.facebook.com/groups/arduinograncanaria&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Arduino Gran Canaria&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -19,7 +19,7 @@
     <message>
         <location filename="../src/mainwindow.ui" line="23"/>
         <source>Visualino</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="74"/>
@@ -29,77 +29,77 @@
     <message>
         <location filename="../src/mainwindow.ui" line="249"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="317"/>
         <source>arduino:avr:uno</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="322"/>
         <source>arduino:avr:nano</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="327"/>
         <source>arduino:avr:mega</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="332"/>
         <source>arduino:avr:bt</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="391"/>
         <source>&amp;File</source>
-        <translation type="unfinished">&amp;Plik</translation>
+        <translation>&amp;Plik</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="395"/>
         <source>Export as...</source>
-        <translation type="unfinished">Eksportuj jako...
+        <translation>Eksportuj jako...
 </translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="418"/>
         <source>&amp;Help</source>
-        <translation type="unfinished">Pomo&amp;c</translation>
+        <translation>Pomo&amp;c</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="424"/>
         <source>&amp;Tools</source>
-        <translation type="unfinished">&amp;Narzędzia</translation>
+        <translation>&amp;Narzędzia</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="463"/>
         <source>toolBar</source>
-        <translation type="unfinished">Pasek narzędzi</translation>
+        <translation>Pasek narzędzi</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="483"/>
         <location filename="../src/mainwindow.ui" line="486"/>
         <location filename="../src/mainwindow.ui" line="656"/>
         <source>Verify</source>
-        <translation type="unfinished">Zweryfikuj</translation>
+        <translation>Weryfikuj</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="489"/>
         <source>Ctrl+R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="498"/>
         <location filename="../src/mainwindow.ui" line="501"/>
         <location filename="../src/mainwindow.ui" line="566"/>
         <source>Upload</source>
-        <translation type="unfinished">Wgraj</translation>
+        <translation>Wgraj</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="510"/>
         <source>Open</source>
-        <translation type="unfinished">Otwórz</translation>
+        <translation>Otwórz</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="519"/>
@@ -107,28 +107,28 @@
         <location filename="../src/mainwindow.cpp" line="398"/>
         <location filename="../src/mainwindow.cpp" line="402"/>
         <source>Save</source>
-        <translation type="unfinished">Zapisz</translation>
+        <translation>Zapisz</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="528"/>
         <location filename="../src/mainwindow.ui" line="542"/>
         <source>New</source>
-        <translation type="unfinished">Nowy</translation>
+        <translation>Nowy</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="677"/>
         <source>List of examples</source>
-        <translation type="unfinished">Lista przykładów</translation>
+        <translation>Lista przykładów</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="682"/>
         <source>Examples...</source>
-        <translation type="unfinished">Przykłady...</translation>
+        <translation>Przykłady...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="697"/>
         <source>Graph</source>
-        <translation type="unfinished">Wykres</translation>
+        <translation>Wykres</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -137,175 +137,175 @@
     <message>
         <location filename="../src/mainwindow.ui" line="545"/>
         <source>Ctrl+N</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="550"/>
         <source>Open...</source>
-        <translation type="unfinished">Otwórz...</translation>
+        <translation>Otwórz...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="553"/>
         <source>Ctrl+O</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="558"/>
         <source>Save...</source>
-        <translation type="unfinished">Zapisz...</translation>
+        <translation>Zapisz...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="561"/>
         <source>Ctrl+S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="569"/>
         <source>Ctrl+U</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="537"/>
         <location filename="../src/mainwindow.ui" line="574"/>
         <source>Preferences</source>
-        <translation type="unfinished">Ustawienia</translation>
+        <translation>Ustawienia</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="577"/>
         <source>Ctrl+,</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="582"/>
         <source>Quit</source>
-        <translation type="unfinished">Wyjście</translation>
+        <translation>Wyjście</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="585"/>
         <source>Ctrl+Q</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="590"/>
         <source>About</source>
-        <translation type="unfinished">O Visualino</translation>
+        <translation>O Visualino</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="598"/>
         <source>Show/hide messages</source>
-        <translation type="unfinished">Pokaż/ukryj komunikaty</translation>
+        <translation>Pokaż/ukryj komunikaty</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="616"/>
         <location filename="../src/mainwindow.ui" line="619"/>
         <source>Monitor</source>
-        <translation type="unfinished">Podgląd</translation>
+        <translation>Podgląd</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="627"/>
         <source>Show/hide monitor</source>
-        <translation type="unfinished">Pokaż/ukryj podgląd</translation>
+        <translation>Pokaż/ukryj podgląd</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="630"/>
         <source>Ctrl+Shift+M</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="635"/>
         <source>Sketch (.ino)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="643"/>
         <source>Save as...</source>
-        <translation type="unfinished">Zapisz jako...</translation>
+        <translation>Zapisz jako...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="648"/>
         <source>Include...</source>
-        <translation type="unfinished">Dołącz...</translation>
+        <translation>Dołącz...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="651"/>
         <source>Include</source>
-        <translation type="unfinished">Dołącz</translation>
+        <translation>Dołącz</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="661"/>
         <source>Show/hide code</source>
-        <translation type="unfinished">Pokaż/ukryj kod</translation>
+        <translation>Pokaż/ukryj kod</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.ui" line="672"/>
         <source>Show/hide icon labels</source>
-        <translation type="unfinished">Pokaż/ukryj etykiety ikon</translation>
+        <translation>Pokaż/ukryj etykiety ikon</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="162"/>
         <source>Examples</source>
-        <translation type="unfinished">Przykłady</translation>
+        <translation>Przykłady</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="176"/>
         <source>Export</source>
-        <translation type="unfinished">Eksport</translation>
+        <translation>Eksport</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="188"/>
         <location filename="../src/mainwindow.cpp" line="418"/>
         <source>Couldn&apos;t open file to save content: %1.</source>
-        <translation type="unfinished">Nie można otworzyć pliku do zapisu zawartości: %1.</translation>
+        <translation>Nie można otworzyć pliku do zapisu zawartości: %1.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="195"/>
         <source>Done exporting: %1.</source>
-        <translation type="unfinished">Eksport wykonany: %1.</translation>
+        <translation>Eksport wykonany: %1.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="226"/>
         <source>Include file</source>
-        <translation type="unfinished">Dołącz plik</translation>
+        <translation>Dołącz plik</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="314"/>
         <source>Open file</source>
-        <translation type="unfinished">Otwórz plik</translation>
+        <translation>Otwórz plik</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="326"/>
         <source>Blockly Files %1</source>
-        <translation type="unfinished">Pliki Blockly %1</translation>
+        <translation>Pliki Blockly %1</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="346"/>
         <source>Couldn&apos;t open file to read content: %1.</source>
-        <translation type="unfinished">Nie można otworzyć pliku do odczytu zawartości: %1.</translation>
+        <translation>Nie można otworzyć pliku do odczytu zawartości: %1.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="428"/>
         <source>Done saving.</source>
-        <translation type="unfinished">Zapis wykonany.</translation>
+        <translation>Zapis wykonany.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="475"/>
         <source>Please, restart the application to display the selected language.</source>
-        <translation type="unfinished">Proszę uruchomić ponownie aplikację aby pokazać ją w wybranym języku.</translation>
+        <translation>Proszę uruchomić ponownie aplikację aby pokazać ją w wybranym języku.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="567"/>
         <source>Finished.</source>
-        <translation type="unfinished">Zakończone.</translation>
+        <translation>Zakończone.</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="576"/>
         <source>Building...</source>
-        <translation type="unfinished">Buduję...</translation>
+        <translation>Buduję...</translation>
     </message>
     <message>
         <location filename="../src/mainwindow.cpp" line="850"/>
         <source>There are unsaved changes that could be lost. Do you want to save them before continuing?</source>
-        <translation type="unfinished">Niezapisane zmiany zostaną utracone. Czy chcesz je teraz zachować?</translation>
+        <translation>Niezapisane zmiany zostaną utracone. Czy chcesz je teraz zachować?</translation>
     </message>
 </context>
 <context>
@@ -313,17 +313,17 @@
     <message>
         <location filename="../src/settingsdialog.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished">Ustawienia</translation>
+        <translation>Ustawienia</translation>
     </message>
     <message>
         <location filename="../src/settingsdialog.ui" line="48"/>
         <source>Arduino IDE Program Path</source>
-        <translation type="unfinished">Ścieżka do programu Arduino IDE</translation>
+        <translation>Ścieżka do programu Arduino IDE</translation>
     </message>
     <message>
         <location filename="../src/settingsdialog.ui" line="71"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>Roboblocks Path</source>
@@ -332,22 +332,22 @@
     <message>
         <location filename="../src/settingsdialog.ui" line="103"/>
         <source>Language</source>
-        <translation type="unfinished">Język</translation>
+        <translation>Język</translation>
     </message>
     <message>
         <location filename="../src/settingsdialog.cpp" line="84"/>
         <source>Arduino IDE</source>
-        <translation type="unfinished">Program Arduino IDE</translation>
+        <translation>Środowisko Arduino IDE</translation>
     </message>
     <message>
         <location filename="../src/settingsdialog.cpp" line="95"/>
         <source>Default settings</source>
-        <translation type="unfinished">Ustawienia domyślne</translation>
+        <translation>Ustawienia domyślne</translation>
     </message>
     <message>
         <location filename="../src/settingsdialog.cpp" line="96"/>
         <source>Are you sure? This will erase your current preferences and replace them with the defaults.</source>
-        <translation type="unfinished">Czy jesteś pewien? Bieżące ustawienia zostaną zastąpione ustawieniami domyślnymi.</translation>
+        <translation>Czy jesteś pewien? Bieżące ustawienia zostaną zastąpione ustawieniami domyślnymi.</translation>
     </message>
 </context>
 </TS>

--- a/ts/visualino_pl-pl.ts
+++ b/ts/visualino_pl-pl.ts
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl_PL">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../src/aboutdialog.ui" line="14"/>
+        <source>Dialog</source>
+        <translation type="unfinished">O Visualino </translation>
+    </message>
+    <message>
+        <location filename="../src/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Visualino is open source software (MIT license). Visit the web site at &lt;a href=&quot;http://www.visualino.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;visualino.net&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;2014-2015 Víctor R. Ruiz &amp;lt;&lt;a href=&quot;mailto:rvr@linotipo.es&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;rvr@linotipo.es&lt;/span&gt;&lt;/a&gt;&amp;gt;&lt;/p&gt;&lt;p&gt;It uses the following open source projects:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.qt.io/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Qt 5&lt;/span&gt;&lt;/a&gt;, The Qt Company (LGPL license 2.1).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://developers.google.com/blockly/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Google Blockly&lt;/span&gt;&lt;/a&gt; (MIT license).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/bq/roboblocks&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Roboblocks&lt;/span&gt;&lt;/a&gt;, bq (LGPL license).&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;This project is done with the help of &lt;a href=&quot;http://www.facebook.com/groups/arduinograncanaria&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Arduino Gran Canaria&lt;/span&gt;&lt;/a&gt; members.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Visualino jest oprogramowaniem Open Source (licencja MIT). Odwiedź witrynę &lt;a href=&quot;http://www.visualino.net/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;visualino.net&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;2014-2015 Víctor R. Ruiz &amp;lt;&lt;a href=&quot;mailto:rvr@linotipo.es&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;rvr@linotipo.es&lt;/span&gt;&lt;/a&gt;&amp;gt;&lt;/p&gt;&lt;p&gt;Używa następujących plików projektów Open Source:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.qt.io/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Qt 5&lt;/span&gt;&lt;/a&gt;, The Qt Company (LGPL license 2.1).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://developers.google.com/blockly/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Google Blockly&lt;/span&gt;&lt;/a&gt; (licencja MIT).&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/bq/roboblocks&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Roboblocks&lt;/span&gt;&lt;/a&gt;, bq (licencja LGPL).&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Ten projekt wykonano z pomocą członków &lt;a href=&quot;http://www.facebook.com/groups/arduinograncanaria&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Arduino Gran Canaria&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/mainwindow.ui" line="23"/>
+        <source>Visualino</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="74"/>
+        <source>about:blank</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="249"/>
+        <source>X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="317"/>
+        <source>arduino:avr:uno</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="322"/>
+        <source>arduino:avr:nano</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="327"/>
+        <source>arduino:avr:mega</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="332"/>
+        <source>arduino:avr:bt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="391"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Plik</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="395"/>
+        <source>Export as...</source>
+        <translation type="unfinished">Eksportuj jako...
+</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="418"/>
+        <source>&amp;Help</source>
+        <translation type="unfinished">Pomo&amp;c</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="424"/>
+        <source>&amp;Tools</source>
+        <translation type="unfinished">&amp;Narzędzia</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="463"/>
+        <source>toolBar</source>
+        <translation type="unfinished">Pasek narzędzi</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="483"/>
+        <location filename="../src/mainwindow.ui" line="486"/>
+        <location filename="../src/mainwindow.ui" line="656"/>
+        <source>Verify</source>
+        <translation type="unfinished">Zweryfikuj</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="489"/>
+        <source>Ctrl+R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="498"/>
+        <location filename="../src/mainwindow.ui" line="501"/>
+        <location filename="../src/mainwindow.ui" line="566"/>
+        <source>Upload</source>
+        <translation type="unfinished">Wgraj</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="510"/>
+        <source>Open</source>
+        <translation type="unfinished">Otwórz</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="519"/>
+        <location filename="../src/mainwindow.cpp" line="172"/>
+        <location filename="../src/mainwindow.cpp" line="398"/>
+        <location filename="../src/mainwindow.cpp" line="402"/>
+        <source>Save</source>
+        <translation type="unfinished">Zapisz</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="528"/>
+        <location filename="../src/mainwindow.ui" line="542"/>
+        <source>New</source>
+        <translation type="unfinished">Nowy</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="677"/>
+        <source>List of examples</source>
+        <translation type="unfinished">Lista przykładów</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="682"/>
+        <source>Examples...</source>
+        <translation type="unfinished">Przykłady...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="697"/>
+        <source>Graph</source>
+        <translation type="unfinished">Wykres</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="obsolete">Ustawienia</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="545"/>
+        <source>Ctrl+N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="550"/>
+        <source>Open...</source>
+        <translation type="unfinished">Otwórz...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="553"/>
+        <source>Ctrl+O</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="558"/>
+        <source>Save...</source>
+        <translation type="unfinished">Zapisz...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="561"/>
+        <source>Ctrl+S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="569"/>
+        <source>Ctrl+U</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="537"/>
+        <location filename="../src/mainwindow.ui" line="574"/>
+        <source>Preferences</source>
+        <translation type="unfinished">Ustawienia</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="577"/>
+        <source>Ctrl+,</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="582"/>
+        <source>Quit</source>
+        <translation type="unfinished">Wyjście</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="585"/>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="590"/>
+        <source>About</source>
+        <translation type="unfinished">O Visualino</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="598"/>
+        <source>Show/hide messages</source>
+        <translation type="unfinished">Pokaż/ukryj komunikaty</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="616"/>
+        <location filename="../src/mainwindow.ui" line="619"/>
+        <source>Monitor</source>
+        <translation type="unfinished">Podgląd</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="627"/>
+        <source>Show/hide monitor</source>
+        <translation type="unfinished">Pokaż/ukryj podgląd</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="630"/>
+        <source>Ctrl+Shift+M</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="635"/>
+        <source>Sketch (.ino)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="643"/>
+        <source>Save as...</source>
+        <translation type="unfinished">Zapisz jako...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="648"/>
+        <source>Include...</source>
+        <translation type="unfinished">Dołącz...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="651"/>
+        <source>Include</source>
+        <translation type="unfinished">Dołącz</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="661"/>
+        <source>Show/hide code</source>
+        <translation type="unfinished">Pokaż/ukryj kod</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="672"/>
+        <source>Show/hide icon labels</source>
+        <translation type="unfinished">Pokaż/ukryj etykiety ikon</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="162"/>
+        <source>Examples</source>
+        <translation type="unfinished">Przykłady</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="176"/>
+        <source>Export</source>
+        <translation type="unfinished">Eksport</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="188"/>
+        <location filename="../src/mainwindow.cpp" line="418"/>
+        <source>Couldn&apos;t open file to save content: %1.</source>
+        <translation type="unfinished">Nie można otworzyć pliku do zapisu zawartości: %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="195"/>
+        <source>Done exporting: %1.</source>
+        <translation type="unfinished">Eksport wykonany: %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <source>Include file</source>
+        <translation type="unfinished">Dołącz plik</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="314"/>
+        <source>Open file</source>
+        <translation type="unfinished">Otwórz plik</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="326"/>
+        <source>Blockly Files %1</source>
+        <translation type="unfinished">Pliki Blockly %1</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="346"/>
+        <source>Couldn&apos;t open file to read content: %1.</source>
+        <translation type="unfinished">Nie można otworzyć pliku do odczytu zawartości: %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="428"/>
+        <source>Done saving.</source>
+        <translation type="unfinished">Zapis wykonany.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="475"/>
+        <source>Please, restart the application to display the selected language.</source>
+        <translation type="unfinished">Proszę uruchomić ponownie aplikację aby pokazać ją w wybranym języku.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="567"/>
+        <source>Finished.</source>
+        <translation type="unfinished">Zakończone.</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="576"/>
+        <source>Building...</source>
+        <translation type="unfinished">Buduję...</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.cpp" line="850"/>
+        <source>There are unsaved changes that could be lost. Do you want to save them before continuing?</source>
+        <translation type="unfinished">Niezapisane zmiany zostaną utracone. Czy chcesz je teraz zachować?</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="14"/>
+        <source>Dialog</source>
+        <translation type="unfinished">Ustawienia</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="48"/>
+        <source>Arduino IDE Program Path</source>
+        <translation type="unfinished">Ścieżka do programu Arduino IDE</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="71"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Roboblocks Path</source>
+        <translation type="obsolete">Ścieżka do Roboblocks</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.ui" line="103"/>
+        <source>Language</source>
+        <translation type="unfinished">Język</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.cpp" line="84"/>
+        <source>Arduino IDE</source>
+        <translation type="unfinished">Program Arduino IDE</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.cpp" line="95"/>
+        <source>Default settings</source>
+        <translation type="unfinished">Ustawienia domyślne</translation>
+    </message>
+    <message>
+        <location filename="../src/settingsdialog.cpp" line="96"/>
+        <source>Are you sure? This will erase your current preferences and replace them with the defaults.</source>
+        <translation type="unfinished">Czy jesteś pewien? Bieżące ustawienia zostaną zastąpione ustawieniami domyślnymi.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Hi
This is Polish translation for Visualino GUI, reworked with qtlinguist (why this tool took my time to discover itself?) - some questions and suggestions (if I can):
1. I translated "Monitor" to "Podgląd" (means: View) because it is more familiar for unexperienced users (young technics/enthusiasts) what about is - "monitor" typically means "screen for computer". Experienced Arduino IDE users should be not disturbed. BUT, as used in Arduino IDE, "monitor" is in fact some kind of terminal (can receive and send through COM), am I right?
2. What about dynamic load localized files (qm) and dynamic language list modification? I spent some time searching where GUI language list is hardcoded, so in effect when located these strings in main module, just hex edited visualino.exe (0.5 distro) to achieve polish GUI. BUT roboblocks disappeared (switched to english and just mixed), so next suggestion:
3. If, for example, only visualino GUI polish (or another) language translation file (qm) exists, but there is no polish (or other actual) roboblocks translation, should program defaults roboblocks to english instead of disappearing?
4. maybe "automatic"/"user language" option in Language, so Visualino will read system/user locale and if got it in resources, will try to use it instead of manual settings?
5. (colleague suggestion): what about highlight code of just translated (or clicked) block? Big educational advantage. Is it any chance to include this behavior in future? (probably there is Github feature for this)

Thanks for great work and apologize for weak english
A.M.Os.
